### PR TITLE
fix: resolve warning for append without groups in Ansible user task

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,8 +10,9 @@
     comment: User for processing ansible tasks
     name:  "{{ ansible_playbook_user }}"
     group: "{{ ansible_playbook_group }}"
-    shell: "/bin/bash"
+    groups: "{{ ansible_playbook_group }}"
     append: yes
+    shell: "/bin/bash"
   tags:
     - ansible-user
 


### PR DESCRIPTION
Fixes warning message:
  Warning: : 'append' is set, but no 'groups' are specified. Use 'groups' for
  appending new groups.This will change to an error in Ansible 2.14.

- Added the 'groups' parameter to the Ansible user task to ensure compatibility with Ansible 2.14.
- Ensured the user is appended to the specified groups without triggering warnings or errors.